### PR TITLE
Add pm2 cleanup tasks and ensure c++ dependencies are always installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ chubbs_apt_dependencies:
   - curl
   - git
   - unzip
+  - gcc-6
+  - g++-6
 
 chubbs_version: "master"
 chubbs_git_url: "https://github.com/onaio/PGRestAPI.git"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,18 @@
     nvm_npm_path: "{{ chubbs_nvm_npm_path }}"
     nvm_version: "{{ chubbs_nvm_version }}"
 
+- name: Install software-properties-common
+  apt:
+    update_cache: yes
+    name: software-properties-common
+  tags:
+    - mapnik
+
+- name: Add ppa:ubuntu-toolchain-r/test into sources list
+  # noqa 305 301
+  shell: add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  become: true
+
 - name: Install dependencies
   apt:
     update_cache: yes
@@ -42,6 +54,8 @@
     version: "{{ chubbs_mapnik_version }}"
     depth: 10
     dest: "{{ chubbs_mapnik_install_dir }}"
+    recursive: yes
+    update: yes
     force: yes
   tags:
     - mapnik

--- a/tasks/pm2.yml
+++ b/tasks/pm2.yml
@@ -56,6 +56,12 @@
   notify:
     - "reload pm2"
 
+- name: Cleanup pm2 processes
+  # noqa 305 301
+  become: true
+  become_user: "root"
+  shell: "killall -u {{ chubbs_system_user }}"
+
 - name: generate an PM2 init service file
   # noqa 305 301
   shell: "{{ chubbs_nvm_pm2_path }} startup {{ chubbs_init_system }} -u {{ chubbs_system_user }} --hp {{ chubbs_system_user_home }}"


### PR DESCRIPTION
Fixes: https://github.com/onaio/ansible-chubbs/issues/6
## Changes introduced in this PR
- Fix test container to ubuntu version to 18.04
- Add cleanup pm2 process task
- Install gcc and g++ 